### PR TITLE
refactor(components): 更新成员角色描述和产品链接

### DIFF
--- a/src/components/MemberView.vue
+++ b/src/components/MemberView.vue
@@ -257,7 +257,7 @@ export default {
       {
         name: "Yealqp",
         avatar: "https://q2.qlogo.cn/headimg_dl?dst_uin=1592239257&spec=4",
-        role: "开发兼运维 / 创始人 / 成员",
+        role: "DevOps / 创始人 / 成员",
         link: "https://github.com/Yealqp",
       },
       {
@@ -277,11 +277,6 @@ export default {
         avatar: "https://q2.qlogo.cn/headimg_dl?dst_uin=3976141098&spec=4",
         role: "联盟网盘维护者",
         link: "https://github.com/chencomcdyun",
-      },
-      {
-        name: "MR.苏",
-        avatar: "https://q2.qlogo.cn/headimg_dl?dst_uin=2748874586&spec=4",
-        role: "成员 / 敬请期待",
       },
     ]);
 

--- a/src/components/ProductView.vue
+++ b/src/components/ProductView.vue
@@ -67,16 +67,16 @@ export default {
     const products = ref([
       {
         name: "XL-ME-Frp-Launcher",
-        link: "https://mefrp-tpca.yealqp.fun/docs/client/XL",
+        link: "https://mefrp-tpca.yealqp.cn/docs/XL",
         icon: "https://images.mcsl.com.cn/new/MCSL2.webp",
         description:
-          "由yealqp使用Tauri框架开发，界面高仿官网样式，可能是目前收录的三个客户端中最美观的一个，也是包体最小的一个。",
+          "由yealqp使用Tauri框架开发，界面高仿官网样式，可能是目前收录的三个客户端中最美观的一个，也可能也是包体最小的一个，亦或是bug最少的一个。",
         image:
           "https://image.mefrp-tpca.yealqp.fun/image/views/yealqp/home.png",
       },
       {
         name: "LX-ME-Frp-Launcher",
-        link: "https://mefrp-tpca.yealqp.fun/docs/client/LX",
+        link: "https://mefrp-tpca.yealqp.cn/docs/LX",
         icon: "https://images.mcsl.com.cn/new/MCServerLauncherFuture.webp",
         description:
           "由灵弦MuaMua使用易语言&Exui开发，界面高仿官方图形化V4.0。",
@@ -85,7 +85,7 @@ export default {
       },
       {
         name: "Plain ME Frp Luncher",
-        link: "https://mefrp-tpca.yealqp.fun/docs/client/qyf",
+        link: "https://mefrp-tpca.yealqp.cn/docs/qyf",
         icon: "https://images.mcsl.com.cn/new/MCSL-Sync.webp",
         description:
           "Plain ME Frp Launcher 使用dotnet提供了简单便捷的操作，可以快速启动实例/隧道。可能也是目前三个产品中唯一一个支持软件内控制台操作的软件。",


### PR DESCRIPTION
- 将Yealqp的角色描述从"开发兼运维"改为更专业的"DevOps"
- 移除不再活跃的成员"MR.苏"
- 更新所有产品的文档链接域名从.fun改为.cn
- 完善XL-ME-Frp-Launcher的描述信息