### PR TITLE
修正下载按钮链接格式错误问题

### DIFF
--- a/src/pages/docs/zl.vue
+++ b/src/pages/docs/zl.vue
@@ -166,7 +166,7 @@
           <UButton 
             size="lg" 
             color="primary"
-            to="znext.ccwu.cc"
+            to="https://znext.ccwu.cc"
             target="_blank"
             class="btn-glow cursor-pointer"
           >


### PR DESCRIPTION
指向链接格式不正确，未加上https://，现已修复并提交pr