### PR TITLE
修复该死的SSL问题，CF不给我三级域名配SSL

### DIFF
--- a/src/pages/docs/fm.vue
+++ b/src/pages/docs/fm.vue
@@ -374,7 +374,7 @@ const updates = ref([])
 // 从 API 获取更新日志
 const fetchChangelog = async () => {
   try {
-    const response = await fetch('https://api.frpc.xiaofanshop.cn/tpca.json')
+    const response = await fetch('http://api.frpc.xiaofanshop.cn/tpca.json')
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)
     }


### PR DESCRIPTION
修改了fm.vue文件
    -const response = await fetch('https://api.frpc.xiaofanshop.cn/tpca.json')
    +const response = await fetch('http://api.frpc.xiaofanshop.cn/tpca.json')